### PR TITLE
Fix period formatting

### DIFF
--- a/website/lib/util.ts
+++ b/website/lib/util.ts
@@ -1,0 +1,3 @@
+export function formatTime(date: Date) {
+    return date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit"})
+}


### PR DESCRIPTION
- Updates prisma.gridLive.create to use prisma.gridLive.upsert to avoid primary key constraint errors
- Updates date related variables to be a bit more understandable, and (I think) more adjustable with a WINDOW constant (can set whether you want the period to be 5 mins, or 10, or 30, etc)
- uses Date.toLocaleTimeString to format the period as string rather than .getHours and .getMinutes
- prints error.stack instead of the error object to log a more helpful error to console.